### PR TITLE
Add package restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ publish/
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/
+packages/
 
 # Windows Azure Build Output
 csx

--- a/Grunt Nuget.csproj
+++ b/Grunt Nuget.csproj
@@ -36,6 +36,7 @@
     <Content Include="Gruntfile.js" />
     <Content Include="libs\nuget.js" />
     <Content Include="tasks\nuget-key.js" />
+    <Content Include="tasks\nuget-restore.js" />
     <Content Include="tasks\nuget-pack.js" />
     <Content Include="libs\NuGet.exe" />
     <Content Include="tasks\nuget-push.js" />
@@ -45,6 +46,7 @@
     <None Include="package.json" />
     <None Include="README.md" />
     <None Include="tests\Package.nuspec" />
+    <None Include="tests\packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
   <ProjectExtensions>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,10 +5,25 @@
                 src: 'tests/Package.nuspec',
                 dest: 'tests/'
             }
+        },
+        nugetrestore: {
+            restore: {
+                src: 'tests/packages.config',
+                dest: 'packages/'
+            }
+        },
+        clean: {
+            pack: {
+                src: 'tests/PackageTest.1.0.0.nupkg'
+            },
+            restore: {
+                src: 'packages'
+            }
         }
     });
 
+    grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadTasks('tasks');
 
-    grunt.registerTask('default', ['nugetpack']);
+    grunt.registerTask('default', ['clean', 'nugetpack', 'nugetrestore']);
 };

--- a/README.md
+++ b/README.md
@@ -36,10 +36,21 @@ For package publication : ([more informations][push-options])
 	nugetpush: {
 		dist: {
 			src: 'tests/*.nupkg',
-			
+ 
 			options: {
 				apiKey: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
 			}
+		}
+	}
+```
+
+For package restore : ([more informations][restore-options])
+
+```javascript
+	nugetrestore: {
+		restore: {
+			src: 'tests/packages.config',
+			dest: 'packages/'
 		}
 	}
 ```
@@ -57,6 +68,7 @@ grunt nugetkey --key=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 [grunt]: https://github.com/gruntjs/grunt
 [pack-options]: https://github.com/spatools/grunt-nuget/wiki/Pack-Options
 [push-options]: https://github.com/spatools/grunt-nuget/wiki/Push-Options
+[restore-options]: https://github.com/spatools/grunt-nuget/wiki/Restore-Options
 [key-options]: https://github.com/spatools/grunt-nuget/wiki/Key-Options
 
 ## Release History

--- a/libs/nuget.js
+++ b/libs/nuget.js
@@ -63,6 +63,12 @@ module.exports = function (grunt) {
         isPackageFile = function (file) {
             return path.extname(file) === ".nupkg";
         },
+        isSolutionFile = function (file) {
+            return path.extname(file) === ".sln";
+        },
+        isConfigFile = function (file) {
+            return path.basename(file) === "packages.config";
+        },
 
         pack = function (path, args, callback) {
             if (!isSpecFile(path)) {
@@ -82,6 +88,15 @@ module.exports = function (grunt) {
             grunt.log.write("Trying to publish NuGet package " + path + ". ");
             grunt.util.spawn({ cmd: nugetPath, args: createArguments("Push", path, args) }, createSpawnCallback(path, callback));
         },
+        restore = function (path, args, callback) {
+            if (!isSolutionFile(path) && !isConfigFile(path)) {
+                callback("File path '" + path + "' is not a valid solution file or packages.config !");
+                return;
+            }
+
+            grunt.log.write("Trying to restore NuGet packages for " + path + ". ");
+            grunt.util.spawn({ cmd: nugetPath, args: createArguments("Restore", path, args) }, createSpawnCallback(path, callback));
+        },
         setapikey = function (key, args, callback) {
             grunt.util.spawn({ cmd: nugetPath, args: createArguments("SetApiKey", key, args) }, createSpawnCallback(null, callback));
         };
@@ -92,6 +107,7 @@ module.exports = function (grunt) {
 
         pack: pack,
         push: push,
+        restore: restore,
         setapikey: setapikey
     };
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/spatools/grunt-nuget/issues"
   },
   "devDependencies": {
-    "grunt": "0.4.x"
+    "grunt": "0.4.x",
+    "grunt-contrib-clean": "~0.5.0"
   },
   "dependencies": {
     "grunt": "0.4.x"

--- a/tasks/nuget-restore.js
+++ b/tasks/nuget-restore.js
@@ -1,0 +1,61 @@
+﻿/*
+ * grunt-nuget
+ * https://github.com/spatools/grunt-nuget
+ * Copyright (c) 2013 SPA Tools
+ * Code below is licensed under MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person 
+ * obtaining a copy of this software and associated documentation 
+ * files (the "Software"), to deal in the Software without restriction, 
+ * including without limitation the rights to use, copy, modify, merge, 
+ * publish, distribute, sublicense, and/or sell copies of the Software, 
+ * and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be 
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+module.exports = function (grunt) {
+    var _ = grunt.util._,
+        async = grunt.util.async,
+        nuget = require("../libs/nuget")(grunt);
+
+    grunt.registerMultiTask('nugetrestore', "NuGet Restore - Restore NuGet packages", function () {
+        var params = this.options(),
+            done = this.async();
+
+        async.forEach(
+            this.files,
+            function (file, callback) {
+                var dest = file.dest || "";
+
+                async.forEach(
+                    file.src,
+                    function (src, complete) {
+                        nuget.restore(src, _.extend(params, { packagesDirectory: dest }), complete);
+                    },
+                    callback
+                );
+            },
+            function (err) {
+                if (err) {
+                    grunt.log.error().error(err);
+                    done(false);
+                    return;
+                }
+
+                grunt.log.ok("NuGet Packages restored !");
+                done();
+            }
+        );
+    });
+};

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="jQuery" version="2.1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
These changes add the ability to do a package restore.

It accepts packages.config or .sln files as source and restores the packages to the _dest_ location.

Documentation is included and detailed documentation has been added to the [wiki](https://github.com/spatools/grunt-nuget/wiki/Restore-Options)

This would fix issue #1.
