### PR TITLE
nugetrestore only pass packagesDirectory when defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+package-lock.json
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+## Release History
+* 0.1.0 Initial Release
+* 0.1.1 Fix issue with OutputDirectory in NuGet Push 
+* 0.1.2
+    * Update NuGet.exe to version 2.8
+    * Add support for csproj files in nugetpack command.
+* 0.1.3
+    * Add package restore command
+    * Added mono support on platforms other than windows
+    * Fix issue when nuget-pack destination directory does not exists
+* 0.1.4
+    * Update NuGet.exe to version 2.8.2
+    * Fix issue in options parsing.
+* 0.1.5
+	* Update NuGet.exe to version 3.2.0
+* 0.1.6
+	* Update NuGet.exe to version 3.4.4
+	* Add default `Source` option in `push` task to allow backward compatibility
+* 0.1.7
+	* Update NuGet.exe to version 3.5.0
+* 0.2.0
+	* Add task nugetupdate 
+* 0.3.0
+	* Update NuGet.exe to version 4.1
+* 0.3.1
+	* Update NuGet.exe to version 4.7.1
+* 0.3.2
+    * Update NuGet.exe to version 5.4.0
+    * Fix packageDirectoty bug with nugetrestore

--- a/README.md
+++ b/README.md
@@ -83,30 +83,3 @@ grunt nugetkey --key=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 [restore-options]: https://github.com/spatools/grunt-nuget/wiki/Restore-Options
 [update-options]: https://github.com/spatools/grunt-nuget/wiki/Update-Options
 [key-options]: https://github.com/spatools/grunt-nuget/wiki/Key-Options
-
-## Release History
-* 0.1.0 Initial Release
-* 0.1.1 Fix issue with OutputDirectory in NuGet Push 
-* 0.1.2
-    * Update NuGet.exe to version 2.8
-    * Add support for csproj files in nugetpack command.
-* 0.1.3
-    * Add package restore command
-    * Added mono support on platforms other than windows
-    * Fix issue when nuget-pack destination directory does not exists
-* 0.1.4
-    * Update NuGet.exe to version 2.8.2
-    * Fix issue in options parsing.
-* 0.1.5
-	* Update NuGet.exe to version 3.2.0
-* 0.1.6
-	* Update NuGet.exe to version 3.4.4
-	* Add default `Source` option in `push` task to allow backward compatibility
-* 0.1.7
-	* Update NuGet.exe to version 3.5.0
-* 0.2.0
-	* Add task nugetupdate 
-* 0.3.0
-	* Update NuGet.exe to version 4.1
-* 0.3.1
-	* Update NuGet.exe to version 4.7.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-nuget",
   "description": "Grunt NuGet interface - Prepare, package and publish your application in NuGet gallery using Grunt JS",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/spatools/grunt-nuget.git",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "grunt-nuget",
+  "name": "@robinherbots/grunt-nuget",
   "description": "Grunt NuGet interface - Prepare, package and publish your application in NuGet gallery using Grunt JS",
   "version": "0.3.2",
   "homepage": "https://github.com/spatools/grunt-nuget.git",
   "license": "MIT",
-  "author": {
-    "name": "SPA Tools",
-    "url": "http://github.com/spatools/"
-  },
+  "author": "SPA Tools (http://github.com/spatools/)",
   "repository": {
     "type": "git",
     "url": "git://github.com/spatools/grunt-nuget.git"
@@ -19,8 +16,8 @@
     "test": "grunt"
   },
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-contrib-clean": "^1.0.0"
+    "grunt": "^1.1.0",
+    "grunt-contrib-clean": "^2.0.0"
   },
   "keywords": [
     "gruntplugin",
@@ -33,5 +30,10 @@
     "restore",
     "publish",
     "gallery"
-  ]
+  ],
+  "main": "Gruntfile.js",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robinherbots/grunt-nuget",
   "description": "Grunt NuGet interface - Prepare, package and publish your application in NuGet gallery using Grunt JS",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "homepage": "https://github.com/spatools/grunt-nuget.git",
   "license": "MIT",
   "author": "SPA Tools (http://github.com/spatools/)",

--- a/tasks/nuget-restore.js
+++ b/tasks/nuget-restore.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
                 async.forEach(
                     file.src,
                     function (src, complete) {
-                        nuget.restore(src, _.extend(params, { packagesDirectory: dest }), complete);
+                        nuget.restore(src, dest ? _.extend(params, { packagesDirectory: dest }) : params, complete);
                     },
                     callback
                 );


### PR DESCRIPTION
@SomaticIT,
When using package restore on a solution (.sln) you do not really specify a directory for the packages.

But when I leave the dest out, it gives an error because the -PackagesDirectory option is passed anyway, which gives an error.

``` 
Missing option value for: '-PackagesDirectory
```

Skipping the option in that cases fixes the issue.

